### PR TITLE
Fix padding_mode option in R2Conv

### DIFF
--- a/e2cnn/nn/modules/r2_conv/r2convolution.py
+++ b/e2cnn/nn/modules/r2_conv/r2convolution.py
@@ -326,7 +326,7 @@ class R2Conv(EquivariantModule):
         
         # use it for convolution and return the result
         
-        if self.padding_mode != 'zeros':
+        if self.padding_mode == 'zeros':
             output = conv2d(input.tensor, filter,
                             stride=self.stride,
                             padding=self.padding,


### PR DESCRIPTION
The condition on the `padding_mode` to check for `zeros` was the wrong way around: If `padding_mode == 'zeros'`, then the default implicit-zero padding of the `Conv2d` module should be used. Else, use a specific padding mode for `torch.nn.functional.pad`.