### PR TITLE
Fix padding in R2Conv for padding_mode other than 'zeros'

### DIFF
--- a/e2cnn/nn/modules/r2_conv/r2convolution.py
+++ b/e2cnn/nn/modules/r2_conv/r2convolution.py
@@ -337,7 +337,6 @@ class R2Conv(EquivariantModule):
             output = conv2d(pad(input.tensor, self._reversed_padding_repeated_twice, self.padding_mode),
                             filter,
                             stride=self.stride,
-                            padding=self.padding,
                             dilation=self.dilation,
                             groups=self.groups,
                             bias=bias)


### PR DESCRIPTION
In the forward pass of R2Conv, padding was applied twice if the padding
mode was anything other than 'zeros', resulting in an incorrect output
shape. This commit fixes the problem by deleting one of the redundant
applications of the padding operation.

Signed-off-by: Ferdia Sherry <fs436@cam.ac.uk>