### PR TITLE
Fix for torch >= 1.9

### DIFF
--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -2,7 +2,7 @@
 from .equivariant_module import EquivariantModule
 
 import torch
-TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:1])
+TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:2])
 
 if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
     from torch._six import container_abcs

--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -2,14 +2,12 @@
 from .equivariant_module import EquivariantModule
 
 import torch
-TORCH_MAJOR = int(torch.__version__.split('.')[0])
-TORCH_MINOR = int(torch.__version__.split('.')[1])
+TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:1])
+
 if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
     from torch._six import container_abcs
 else:
     import collections.abc as container_abcs
-
-import torch
 
 from typing import List, Iterable
 

--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -1,7 +1,13 @@
 
 from .equivariant_module import EquivariantModule
 
-from torch._six import container_abcs
+import torch
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+    from torch._six import container_abcs
+else:
+    import collections.abc as container_abcs
 
 import torch
 

--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -4,7 +4,7 @@ from .equivariant_module import EquivariantModule
 import torch
 TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:2])
 
-if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+if TORCH_MAJOR == 1 and TORCH_MINOR <= 8:
     from torch._six import container_abcs
 else:
     import collections.abc as container_abcs


### PR DESCRIPTION
In its current form `from e2cnn import nn` results in a crash for `torch >= 1.8`. Here's a fix.

Source for this fix: [this issue](https://github.com/NVIDIA/apex/pull/1049).