### PR TITLE
Add missing discretization argument

### DIFF
--- a/e2cnn/gspaces/r2/general_r2.py
+++ b/e2cnn/gspaces/r2/general_r2.py
@@ -190,7 +190,7 @@ class GeneralOnR2(GSpace):
         if (in_repr.name, out_repr.name) not in self._fields_intertwiners_basis_memory[key]:
             # TODO - we could use a flag in the args to choose whether to store it or not
             
-            basis = self._diffop_basis_generator(in_repr, out_repr, max_power, **kwargs)
+            basis = self._diffop_basis_generator(in_repr, out_repr, max_power, discretization, **kwargs)
        
             # store the basis in the dictionary
             self._fields_intertwiners_basis_memory[key][(in_repr.name, out_repr.name)] = basis


### PR DESCRIPTION
PDOs currently seem broken because the `discretization` argument isn't passed on in one place. From a brief look, I'd guess that this was introduced in https://github.com/QUVA-Lab/e2cnn/commit/135f964be8793171ef1e1f7cdf7fe0bf5990a0c4 (since `discretization` was part of `**kwargs` before then). Should be fixed with this PR.