### PR TITLE
[Fix] Fix deprecated `np.bool`

### DIFF
--- a/e2cnn/kernels/basis.py
+++ b/e2cnn/kernels/basis.py
@@ -124,7 +124,7 @@ class KernelBasis(Basis):
         """
         
         assert mask.shape == (self.dim, )
-        assert mask.dtype == np.bool
+        assert mask.dtype == bool
 
         basis = self.sample(points)
         


### PR DESCRIPTION
## Motivation

`np.bool` is deprecated which was alias for python `bool`.

## Modification

Replace `np.bool` with `bool`.

Please check https://github.com/open-mmlab/mmdetection/pull/9537