### PR TITLE
Cannot import name container_abcs in python 3.6 version (e2cnn_py36)

### DIFF
--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -2,7 +2,7 @@
 from .equivariant_module import EquivariantModule
 
 import torch
-TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:1])
+TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:2])
 
 if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
     from torch._six import container_abcs

--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -2,14 +2,12 @@
 from .equivariant_module import EquivariantModule
 
 import torch
-TORCH_MAJOR = int(torch.__version__.split('.')[0])
-TORCH_MINOR = int(torch.__version__.split('.')[1])
+TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:1])
+
 if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
     from torch._six import container_abcs
 else:
     import collections.abc as container_abcs
-
-import torch
 
 from typing import List, Iterable
 

--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -1,7 +1,13 @@
 
 from .equivariant_module import EquivariantModule
 
-from torch._six import container_abcs
+import torch
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+    from torch._six import container_abcs
+else:
+    import collections.abc as container_abcs
 
 import torch
 

--- a/e2cnn/nn/modules/module_list.py
+++ b/e2cnn/nn/modules/module_list.py
@@ -4,7 +4,7 @@ from .equivariant_module import EquivariantModule
 import torch
 TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[:2])
 
-if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+if TORCH_MAJOR == 1 and TORCH_MINOR <= 8:
     from torch._six import container_abcs
 else:
     import collections.abc as container_abcs


### PR DESCRIPTION
As documented in https://github.com/QUVA-Lab/e2cnn/issues/63, the legacy Python 3.6 branch remains broken. 

This issue appears to have been resolved on the main branch as documented in https://github.com/QUVA-Lab/e2cnn/issues/48, but for `Python 3.6` with `PyTorch==1.9.0`, I get the following error on the Jetson-Nano:

```
root@nano:/home/e2cnn# python3
Python 3.6.9 (default, Jan 26 2021, 15:33:00)
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> torch.__version__
'1.9.0'
>>> from e2cnn import nn as e2nn
2023-02-24 06:26:04.142987: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.10.2
WARNING:tensorflow:Deprecation warnings have been disabled. Set TF_ENABLE_DEPRECATION_WARNINGS=1 to re-enable them.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/flairop/e2cnn/e2cnn/nn/__init__.py", line 5, in <module>
    from .modules import *
  File "/home/flairop/e2cnn/e2cnn/nn/modules/__init__.py", line 50, in <module>
    from .module_list import ModuleList
  File "/home/flairop/e2cnn/e2cnn/nn/modules/module_list.py", line 4, in <module>
    from torch._six import container_abcs
ImportError: cannot import name 'container_abcs'
>>>
```

This PR fixes the issue on the `legacy_py3.6` branch by cherry-picking commits from https://github.com/QUVA-Lab/e2cnn/pull/44